### PR TITLE
Make configuration components inspectable by bevy-inspector-egui

### DIFF
--- a/src/platformer.rs
+++ b/src/platformer.rs
@@ -14,6 +14,9 @@ pub struct TnuaPlatformerPlugin;
 /// won't work very well for vehicle controls though.
 impl Plugin for TnuaPlatformerPlugin {
     fn build(&self, app: &mut App) {
+        app.register_type::<TnuaPlatformerConfig>();
+        app.register_type::<TnuaFreeFallBehavior>();
+
         app.configure_sets(
             (
                 TnuaPipelineStages::Sensors,
@@ -62,7 +65,7 @@ impl TnuaPlatformerBundle {
 }
 
 /// Movement settings for a platformer-like character controlled by Tnua.
-#[derive(Component)]
+#[derive(Component, Reflect)]
 pub struct TnuaPlatformerConfig {
     /// The speed the character will try to reach when
     /// [`desired_velocity`](TnuaPlatformerControls::desired_velocity) is set to a unit vector.
@@ -187,7 +190,7 @@ pub struct TnuaPlatformerConfig {
     pub turning_angvel: f32,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Reflect)]
 pub enum TnuaFreeFallBehavior {
     /// Apply extra gravitiy during free fall.
     ///


### PR DESCRIPTION
This adds `Reflect` derives for `TnuaPlatformerConfig` and `TnuaFreeFallBehavior` and adds them to the app's type registry.

This makes them inspectable / editable with [bevy-inspector-egui](https://github.com/jakobhellermann/bevy-inspector-egui).

This should be harmless for non-users of `bevy-inspector-egui`. It should also make the components serializable in bevy scenes. (But to totally  purpose, the rest of other components of `TnuaPlatformerBundle` and their properties need to implement `Reflect` as well.)


https://user-images.githubusercontent.com/200550/232180304-1e264c08-54eb-4017-b861-af6f615dc563.mp4

