### PR TITLE
Fix license key in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["examples"]
 [workspace.package]
 edition = "2021"
 authors = ["IdanArye <idanarye@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/idanarye/bevy-tnua"
 categories = ["game-development"]
 keywords = ["bevy", "gamedev", "locomotion", "game-controls"]


### PR DESCRIPTION
The Cargo manifest format requires a specific syntax for specifying the license key. `MIT/Apache-2.0` is invalid in that syntax, so some tools might not recognize the license. You can read more about the syntax in [the Cargo reference format docs](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields).

Instead, we now use `MIT OR Apache-2.0`, which is the intended way to write this license.