### PR TITLE
typo: strengh -> strength

### DIFF
--- a/demos/src/ui/tuning.rs
+++ b/demos/src/ui/tuning.rs
@@ -103,7 +103,7 @@ impl UiTunable for TnuaBuiltinWalk {
     fn tune(&mut self, ui: &mut egui::Ui) {
         ui.add(egui::Slider::new(&mut self.float_height, 0.0..=10.0).text("Float At"));
         ui.add(egui::Slider::new(&mut self.cling_distance, 0.0..=10.0).text("Cling Distance"));
-        ui.add(egui::Slider::new(&mut self.spring_strengh, 0.0..=4000.0).text("Spring Strengh"));
+        ui.add(egui::Slider::new(&mut self.spring_strength, 0.0..=4000.0).text("Spring Strength"));
         ui.add(egui::Slider::new(&mut self.spring_dampening, 0.0..=1.9).text("Spring Dampening"));
         slider_or_infinity(ui, "Acceleration", &mut self.acceleration, 0.0..=200.0);
         slider_or_infinity(

--- a/src/builtins/walk.rs
+++ b/src/builtins/walk.rs
@@ -66,7 +66,7 @@ pub struct TnuaBuiltinWalk {
     ///
     /// The actual force applied is in direct linear relationship to the displacement from the
     /// `float_height`.
-    pub spring_strengh: Float,
+    pub spring_strength: Float,
 
     /// A force that slows down the characters vertical spring motion.
     ///
@@ -128,7 +128,7 @@ impl Default for TnuaBuiltinWalk {
             desired_forward: None,
             float_height: 0.0,
             cling_distance: 1.0,
-            spring_strengh: 400.0,
+            spring_strength: 400.0,
             spring_dampening: 1.2,
             acceleration: 60.0,
             air_acceleration: 20.0,
@@ -467,7 +467,7 @@ impl TnuaBuiltinWalk {
         ctx: &TnuaBasisContext,
         spring_offset: Float,
     ) -> TnuaVelChange {
-        let spring_force: Float = spring_offset * self.spring_strengh;
+        let spring_force: Float = spring_offset * self.spring_strength;
 
         let relative_velocity = state
             .effective_velocity


### PR DESCRIPTION
Hi, I was working on a platformer and noticed a typo with the field `spring_strengh`. I believe it should be `spring_strength` 😄 