### PR TITLE
TnuaGravity component

### DIFF
--- a/avian2d/src/lib.rs
+++ b/avian2d/src/lib.rs
@@ -70,6 +70,7 @@ impl Plugin for TnuaAvian2dPlugin {
         );
         app.register_required_components::<TnuaSubservientSensor, Position>();
         app.register_required_components::<TnuaSubservientSensor, Rotation>();
+        app.register_required_components_with::<TnuaGravity, GravityScale>(|| GravityScale(0.0));
     }
 }
 
@@ -110,10 +111,7 @@ fn update_rigid_body_trackers_system(
             rotation: Quaternion::from(*rotation).adjust_precision(),
             velocity: linaer_velocity.0.extend(0.0),
             angvel: Vector3::new(0.0, 0.0, angular_velocity.0),
-            gravity: tnua_gravity
-                .copied()
-                .map(|g| g.0)
-                .unwrap_or(gravity.0.extend(0.0)),
+            gravity: tnua_gravity.map(|g| g.0).unwrap_or(gravity.0.extend(0.0)),
         };
     }
 }
@@ -355,6 +353,8 @@ fn apply_motors_system(
                 inertia.value() * motor.ang.acceleration.z,
             );
         }
-        external_force.apply_force(tnua_gravity.copied().unwrap_or_default().0.xy());
+        if let Some(gravity) = tnua_gravity {
+            external_force.apply_force(gravity.0.truncate());
+        }
     }
 }

--- a/avian3d/src/lib.rs
+++ b/avian3d/src/lib.rs
@@ -79,6 +79,7 @@ impl Plugin for TnuaAvian3dPlugin {
         );
         app.register_required_components::<TnuaSubservientSensor, Position>();
         app.register_required_components::<TnuaSubservientSensor, Rotation>();
+        app.register_required_components_with::<TnuaGravity, GravityScale>(|| GravityScale(0.0));
     }
 }
 
@@ -119,7 +120,7 @@ fn update_rigid_body_trackers_system(
             rotation: rotation.adjust_precision(),
             velocity: linaer_velocity.0.adjust_precision(),
             angvel: angular_velocity.0.adjust_precision(),
-            gravity: tnua_gravity.copied().map(|g| g.0).unwrap_or(gravity.0),
+            gravity: tnua_gravity.map(|g| g.0).unwrap_or(gravity.0),
         };
     }
 }
@@ -366,6 +367,8 @@ fn apply_motors_system(
                 inertia.value() * motor.ang.acceleration,
             );
         }
-        external_force.apply_force(tnua_gravity.copied().unwrap_or_default().0);
+        if let Some(gravity) = tnua_gravity {
+            external_force.apply_force(gravity.0);
+        }
     }
 }

--- a/physics-integration-layer/src/data_for_backends.rs
+++ b/physics-integration-layer/src/data_for_backends.rs
@@ -219,11 +219,5 @@ impl TnuaGhostSensor {
 #[derive(Component, Default, Debug)]
 pub struct TnuaGhostPlatform;
 
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug)]
 pub struct TnuaGravity(pub Vector3);
-
-impl Default for TnuaGravity {
-    fn default() -> Self {
-        TnuaGravity(Vector3::ZERO)
-    }
-}


### PR DESCRIPTION
As per the discussion here: https://github.com/idanarye/bevy-tnua/discussions/83
I have implemented the TnuaGravity component which allows the gravity applied to TnuaController to be overridden. This appears to be the approach that Avian encourages based on their examples with ControllerGravity.
https://github.com/Jondolf/avian/blob/v0.2.1/crates/avian3d/examples/kinematic_character_3d/plugin.rs

Both Avian and Rapier support a scalar GravityScale component which allows scaling each RigidBody's gravity independently. So I believe it is easier to require the user to do that than to try and reverse the work done by the physics engine. After testing TnuaGravity with the platformer demos, this seems to be unnecessary in practice for some reason.

In the platformer demos, adding TnuaGravity to the player with a specific vector value apparently has the same effect as changing the Gravity resource to the same value. There are some issues with certain values of gravity, but this is not exclusive to TnuaGravity and has the same effect with the physics engine gravity. For example, with small gravity values, the jump is also very small.