### PR TITLE
correctly handle child colliders 

### DIFF
--- a/avian2d/src/lib.rs
+++ b/avian2d/src/lib.rs
@@ -125,6 +125,7 @@ fn update_proximity_sensors_system(
     other_object_query: Query<(
         Option<(&Position, &LinearVelocity, &AngularVelocity)>,
         Option<&CollisionLayers>,
+        Option<&ColliderParent>,
         Has<TnuaGhostPlatform>,
         Has<Sensor>,
     )>,
@@ -190,12 +191,21 @@ fn update_proximity_sensors_system(
                 let Ok((
                     entity_kinematic_data,
                     entity_collision_layers,
+                    entity_collider_parent,
                     entity_is_ghost,
                     entity_is_sensor,
                 )) = other_object_query.get(entity)
                 else {
                     return false;
                 };
+
+
+                if let Some(parent) = entity_collider_parent {
+                    // Collider is child of our rigid body. ignore.
+                    if parent.get() == owner_entity {
+                        return true;
+                    }
+                }
 
                 let entity_linvel;
                 let entity_angvel;

--- a/avian3d/src/lib.rs
+++ b/avian3d/src/lib.rs
@@ -133,6 +133,7 @@ fn update_proximity_sensors_system(
     other_object_query: Query<(
         Option<(&Position, &LinearVelocity, &AngularVelocity)>,
         Option<&CollisionLayers>,
+        Option<&ColliderParent>,
         Has<TnuaGhostPlatform>,
         Has<Sensor>,
     )>,
@@ -199,12 +200,20 @@ fn update_proximity_sensors_system(
                 let Ok((
                     entity_kinematic_data,
                     entity_collision_layers,
+                    entity_collision_parent,
                     entity_is_ghost,
                     entity_is_sensor,
                 )) = other_object_query.get(entity)
                 else {
                     return false;
                 };
+
+                if let Some(parent) = entity_collision_parent {
+                    // Collider is child of our rigid body. ignore.
+                    if parent.get() == owner_entity {
+                        return true;
+                    }
+                }
 
                 let entity_linvel;
                 let entity_angvel;

--- a/avian3d/src/lib.rs
+++ b/avian3d/src/lib.rs
@@ -200,7 +200,7 @@ fn update_proximity_sensors_system(
                 let Ok((
                     entity_kinematic_data,
                     entity_collision_layers,
-                    entity_collision_parent,
+                    entity_collider_parent,
                     entity_is_ghost,
                     entity_is_sensor,
                 )) = other_object_query.get(entity)
@@ -208,7 +208,7 @@ fn update_proximity_sensors_system(
                     return false;
                 };
 
-                if let Some(parent) = entity_collision_parent {
+                if let Some(parent) = entity_collider_parent {
                     // Collider is child of our rigid body. ignore.
                     if parent.get() == owner_entity {
                         return true;


### PR DESCRIPTION
Avian allows having colliders as children of a rigid_body.
Currently tnua only filters out the TnuaController entity, but we need to filter out these attached colliders as well.

Avian colliders have a ColliderParent(entity) component which points to the rigid_body, which we can use to filter.

- [x] add fix to avian2d
  - Note that I have only tested this for avian3d. The code looked near identical to avian2d, so it probably works.
- [x] check that `cargo test` passes
- [  ] could use an example
- [  ] test case?