### PR TITLE
DRAFT: Update bevy to 0.16 rc 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,14 @@ exclude = ["assets"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.16.0-rc.5", default-features = false, features = [
+bevy = { version = "0.16.0", default-features = false, features = [
     "bevy_log",
 ] }
 bevy-tnua-physics-integration-layer = { version = "^0.6", path = "physics-integration-layer" }
 thiserror = "2.0.12"
 
 [dev-dependencies]
-bevy = { version = "0.16.0-rc.5", default-features = false, features = [
+bevy = { version = "0.16.0", default-features = false, features = [
     "animation",
     "bevy_asset",
     # "bevy_audio",
@@ -62,7 +62,7 @@ bevy = { version = "0.16.0-rc.5", default-features = false, features = [
     "x11",
     # "filesystem_watcher",
 ] }
-avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "7211ecfebb263412f3f0dc095c6e16e12615a229", features = [
+avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "f0d5b86b582c0d7074f0b084dd666e549acc767e", features = [
     "3d",
     "debug-plugin",
     "parallel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,13 +42,11 @@ thiserror = "2.0.12"
 
 [dev-dependencies]
 bevy = { version = "0.16.0-rc.5", default-features = false, features = [
-    # "std",
-    "bevy_log",
-
     "animation",
     "bevy_asset",
     # "bevy_audio",
     "bevy_gilrs",
+    "bevy_log",
     # "bevy_scene",
     # "bevy_winit",
     "bevy_render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,14 @@ exclude = ["assets"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+bevy = { version = "0.16.0-rc.5", default-features = false, features = [
     "bevy_log",
 ] }
 bevy-tnua-physics-integration-layer = { version = "^0.6", path = "physics-integration-layer" }
 thiserror = "2.0.12"
 
 [dev-dependencies]
-bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+bevy = { version = "0.16.0-rc.5", default-features = false, features = [
     # "std",
     "bevy_log",
 
@@ -64,51 +64,7 @@ bevy = { version = "0.16.0-rc.3", default-features = false, features = [
     "x11",
     # "filesystem_watcher",
 ] }
-bevy_a11y = "=0.16.0-rc.3"
-bevy_animation = "=0.16.0-rc.3"
-bevy_app = "=0.16.0-rc.3"
-bevy_asset = "=0.16.0-rc.3"
-bevy_audio = "=0.16.0-rc.3"
-bevy_color = "=0.16.0-rc.3"
-bevy_core_pipeline = "=0.16.0-rc.3"
-bevy_derive = "=0.16.0-rc.3"
-bevy_dev_tools = "=0.16.0-rc.3"
-bevy_diagnostic = "=0.16.0-rc.3"
-bevy_dylib = "=0.16.0-rc.3"
-bevy_ecs = "=0.16.0-rc.3"
-bevy_encase_derive = "=0.16.0-rc.3"
-bevy_gilrs = "=0.16.0-rc.3"
-bevy_gizmos = "=0.16.0-rc.3"
-bevy_gltf = "=0.16.0-rc.3"
-bevy_image = "=0.16.0-rc.3"
-bevy_input = "=0.16.0-rc.3"
-bevy_input_focus = "=0.16.0-rc.3"
-bevy_internal = "=0.16.0-rc.3"
-bevy_log = "=0.16.0-rc.3"
-bevy_macro_utils = "=0.16.0-rc.3"
-bevy_math = "=0.16.0-rc.3"
-bevy_mesh = "=0.16.0-rc.3"
-bevy_mikktspace = "=0.16.0-rc.3"
-bevy_pbr = "=0.16.0-rc.3"
-bevy_picking = "=0.16.0-rc.3"
-bevy_platform_support = "=0.16.0-rc.3"
-bevy_ptr = "=0.16.0-rc.3"
-bevy_reflect = "=0.16.0-rc.3"
-bevy_remote = "=0.16.0-rc.3"
-bevy_render = "=0.16.0-rc.3"
-bevy_scene = "=0.16.0-rc.3"
-bevy_sprite = "=0.16.0-rc.3"
-bevy_state = "=0.16.0-rc.3"
-bevy_tasks = "=0.16.0-rc.3"
-bevy_text = "=0.16.0-rc.3"
-bevy_time = "=0.16.0-rc.3"
-bevy_transform = "=0.16.0-rc.3"
-bevy_ui = "=0.16.0-rc.3"
-bevy_utils = "=0.16.0-rc.3"
-bevy_window = "=0.16.0-rc.3"
-bevy_winit = "=0.16.0-rc.3"
-
-avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "f041bf678dd8b75cf4408fc08cc3c6036bcdafb4", features = [
+avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "7211ecfebb263412f3f0dc095c6e16e12615a229", features = [
     "3d",
     "debug-plugin",
     "parallel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,10 @@
 [workspace]
 members = [
     "physics-integration-layer",
-    "rapier2d", "rapier3d",
-    "avian2d", "avian3d",
+    "rapier2d",
+    "rapier3d",
+    "avian2d",
+    "avian3d",
     "demos",
 ]
 default-members = [".", "demos"]
@@ -27,20 +29,23 @@ categories.workspace = true
 keywords.workspace = true
 documentation = "https://docs.rs/bevy-tnua"
 readme = "README.md"
-exclude = [
-    "assets",
-]
+exclude = ["assets"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "^0.15", default-features = false }
+bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+    "bevy_log",
+] }
 bevy-tnua-physics-integration-layer = { version = "^0.6", path = "physics-integration-layer" }
 thiserror = "2.0.12"
 
 [dev-dependencies]
-bevy = { version = "^0.15", default-features = false, features = [
-     "animation",
+bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+    # "std",
+    "bevy_log",
+
+    "animation",
     "bevy_asset",
     # "bevy_audio",
     "bevy_gilrs",
@@ -59,7 +64,56 @@ bevy = { version = "^0.15", default-features = false, features = [
     "x11",
     # "filesystem_watcher",
 ] }
-avian3d = { version = "^0.2", features = ["3d", "debug-plugin", "parallel", "parry-f32"] }
+bevy_a11y = "=0.16.0-rc.3"
+bevy_animation = "=0.16.0-rc.3"
+bevy_app = "=0.16.0-rc.3"
+bevy_asset = "=0.16.0-rc.3"
+bevy_audio = "=0.16.0-rc.3"
+bevy_color = "=0.16.0-rc.3"
+bevy_core_pipeline = "=0.16.0-rc.3"
+bevy_derive = "=0.16.0-rc.3"
+bevy_dev_tools = "=0.16.0-rc.3"
+bevy_diagnostic = "=0.16.0-rc.3"
+bevy_dylib = "=0.16.0-rc.3"
+bevy_ecs = "=0.16.0-rc.3"
+bevy_encase_derive = "=0.16.0-rc.3"
+bevy_gilrs = "=0.16.0-rc.3"
+bevy_gizmos = "=0.16.0-rc.3"
+bevy_gltf = "=0.16.0-rc.3"
+bevy_image = "=0.16.0-rc.3"
+bevy_input = "=0.16.0-rc.3"
+bevy_input_focus = "=0.16.0-rc.3"
+bevy_internal = "=0.16.0-rc.3"
+bevy_log = "=0.16.0-rc.3"
+bevy_macro_utils = "=0.16.0-rc.3"
+bevy_math = "=0.16.0-rc.3"
+bevy_mesh = "=0.16.0-rc.3"
+bevy_mikktspace = "=0.16.0-rc.3"
+bevy_pbr = "=0.16.0-rc.3"
+bevy_picking = "=0.16.0-rc.3"
+bevy_platform_support = "=0.16.0-rc.3"
+bevy_ptr = "=0.16.0-rc.3"
+bevy_reflect = "=0.16.0-rc.3"
+bevy_remote = "=0.16.0-rc.3"
+bevy_render = "=0.16.0-rc.3"
+bevy_scene = "=0.16.0-rc.3"
+bevy_sprite = "=0.16.0-rc.3"
+bevy_state = "=0.16.0-rc.3"
+bevy_tasks = "=0.16.0-rc.3"
+bevy_text = "=0.16.0-rc.3"
+bevy_time = "=0.16.0-rc.3"
+bevy_transform = "=0.16.0-rc.3"
+bevy_ui = "=0.16.0-rc.3"
+bevy_utils = "=0.16.0-rc.3"
+bevy_window = "=0.16.0-rc.3"
+bevy_winit = "=0.16.0-rc.3"
+
+avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "f041bf678dd8b75cf4408fc08cc3c6036bcdafb4", features = [
+    "3d",
+    "debug-plugin",
+    "parallel",
+    "parry-f32",
+] }
 bevy-tnua-avian3d = { path = "avian3d" }
 
 [package.metadata.docs.rs]

--- a/avian2d/Cargo.toml
+++ b/avian2d/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/bevy-tnua-avian2d"
 readme = "../README.md"
 
 [dependencies]
-bevy = { version = "0.16.0-rc.3", default-features = false }
-avian2d = { git = "https://github.com/Jondolf/avian.git", rev = "f041bf678dd8b75cf4408fc08cc3c6036bcdafb4", default-features = false, features = [
+bevy = { version = "0.16.0-rc.5", default-features = false }
+avian2d = { git = "https://github.com/Jondolf/avian.git", rev = "7211ecfebb263412f3f0dc095c6e16e12615a229", default-features = false, features = [
     "2d",
     "debug-plugin",
     "parallel",

--- a/avian2d/Cargo.toml
+++ b/avian2d/Cargo.toml
@@ -12,8 +12,12 @@ documentation = "https://docs.rs/bevy-tnua-avian2d"
 readme = "../README.md"
 
 [dependencies]
-bevy = { version = "^0.15", default-features = false }
-avian2d = { version = "^0.2", default-features = false, features = ["2d", "debug-plugin", "parallel"]}
+bevy = { version = "0.16.0-rc.3", default-features = false }
+avian2d = { git = "https://github.com/Jondolf/avian.git", rev = "f041bf678dd8b75cf4408fc08cc3c6036bcdafb4", default-features = false, features = [
+    "2d",
+    "debug-plugin",
+    "parallel",
+] }
 bevy-tnua-physics-integration-layer = { version = "^0.6", path = "../physics-integration-layer" }
 
 [package.metadata.docs.rs]
@@ -21,7 +25,7 @@ all-features = true
 features = ["bevy/bevy_asset"]
 
 [features]
-default = [  "avian2d/f32", "avian2d/parry-f32" ]
+default = ["avian2d/f32", "avian2d/parry-f32"]
 f64 = [
     "avian2d/f64",
     "avian2d/parry-f64",

--- a/avian2d/Cargo.toml
+++ b/avian2d/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 bevy = { version = "0.16.0-rc.5", default-features = false }
-avian2d = { git = "https://github.com/Jondolf/avian.git", rev = "7211ecfebb263412f3f0dc095c6e16e12615a229", default-features = false, features = [
+avian2d = { git = "https://github.com/Jondolf/avian.git", rev = "f0d5b86b582c0d7074f0b084dd666e549acc767e", default-features = false, features = [
     "2d",
     "debug-plugin",
     "parallel",

--- a/avian2d/src/lib.rs
+++ b/avian2d/src/lib.rs
@@ -136,7 +136,7 @@ fn update_proximity_sensors_system(
     other_object_query: Query<(
         Option<(&Position, &LinearVelocity, &AngularVelocity)>,
         Option<&CollisionLayers>,
-        Option<&ColliderParent>,
+        Option<&ColliderOf>,
         Has<TnuaGhostPlatform>,
         Has<Sensor>,
     )>,

--- a/avian2d/src/lib.rs
+++ b/avian2d/src/lib.rs
@@ -9,6 +9,7 @@
 use avian2d::math::{AdjustPrecision, AsF32};
 use avian2d::{prelude::*, schedule::PhysicsStepSet};
 use bevy::ecs::schedule::{InternedScheduleLabel, ScheduleLabel};
+use bevy::ecs::relationship::Relationship;
 use bevy::prelude::*;
 use bevy_tnua_physics_integration_layer::data_for_backends::{
     TnuaGhostPlatform, TnuaGhostSensor, TnuaGravity, TnuaMotor, TnuaProximitySensor,

--- a/avian3d/Cargo.toml
+++ b/avian3d/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 bevy = { version = "0.16.0-rc.5", default-features = false }
-avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "7211ecfebb263412f3f0dc095c6e16e12615a229", default-features = false, features = [
+avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "f0d5b86b582c0d7074f0b084dd666e549acc767e", default-features = false, features = [
     "3d",
     "debug-plugin",
     "parallel",

--- a/avian3d/Cargo.toml
+++ b/avian3d/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/bevy-tnua-avian3d"
 readme = "../README.md"
 
 [dependencies]
-bevy = { version = "0.16.0-rc.3", default-features = false }
-avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "f041bf678dd8b75cf4408fc08cc3c6036bcdafb4", default-features = false, features = [
+bevy = { version = "0.16.0-rc.5", default-features = false }
+avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "7211ecfebb263412f3f0dc095c6e16e12615a229", default-features = false, features = [
     "3d",
     "debug-plugin",
     "parallel",

--- a/avian3d/Cargo.toml
+++ b/avian3d/Cargo.toml
@@ -12,8 +12,12 @@ documentation = "https://docs.rs/bevy-tnua-avian3d"
 readme = "../README.md"
 
 [dependencies]
-bevy = { version = "^0.15", default-features = false }
-avian3d = { version = "^0.2", default-features = false, features = ["3d", "debug-plugin", "parallel"] }
+bevy = { version = "0.16.0-rc.3", default-features = false }
+avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "f041bf678dd8b75cf4408fc08cc3c6036bcdafb4", default-features = false, features = [
+    "3d",
+    "debug-plugin",
+    "parallel",
+] }
 bevy-tnua-physics-integration-layer = { version = "^0.6", path = "../physics-integration-layer" }
 
 [package.metadata.docs.rs]
@@ -21,5 +25,5 @@ all-features = true
 features = ["bevy/bevy_asset"]
 
 [features]
-default = [  "avian3d/parry-f32" ]
+default = ["avian3d/parry-f32"]
 f64 = ["avian3d/parry-f64", "bevy-tnua-physics-integration-layer/f64"]

--- a/avian3d/src/lib.rs
+++ b/avian3d/src/lib.rs
@@ -10,8 +10,10 @@ use avian3d::{
     dynamics::rigid_body::mass_properties::components::GlobalAngularInertia, prelude::*,
     schedule::PhysicsStepSet,
 };
+use bevy::ecs::relationship::Relationship;
 use bevy::ecs::schedule::{InternedScheduleLabel, ScheduleLabel};
 use bevy::prelude::*;
+// use bevy::ecs::relationship::Relationship;
 use bevy_tnua_physics_integration_layer::math::AsF32;
 use bevy_tnua_physics_integration_layer::math::Float;
 use bevy_tnua_physics_integration_layer::math::Vector3;
@@ -145,7 +147,7 @@ fn update_proximity_sensors_system(
     other_object_query: Query<(
         Option<(&Position, &LinearVelocity, &AngularVelocity)>,
         Option<&CollisionLayers>,
-        Option<&ColliderParent>,
+        Option<&ColliderOf>,
         Has<TnuaGhostPlatform>,
         Has<Sensor>,
     )>,
@@ -212,7 +214,7 @@ fn update_proximity_sensors_system(
                 let Ok((
                     entity_kinematic_data,
                     entity_collision_layers,
-                    entity_collider_parent,
+                    entity_collider_of,
                     entity_is_ghost,
                     entity_is_sensor,
                 )) = other_object_query.get(entity)
@@ -220,9 +222,9 @@ fn update_proximity_sensors_system(
                     return false;
                 };
 
-                if let Some(parent) = entity_collider_parent {
+                if let Some(relation) = entity_collider_of {
                     // Collider is child of our rigid body. ignore.
-                    if parent.get() == owner_entity {
+                    if relation.get() == owner_entity {
                         return true;
                     }
                 }

--- a/avian3d/src/lib.rs
+++ b/avian3d/src/lib.rs
@@ -13,7 +13,6 @@ use avian3d::{
 use bevy::ecs::relationship::Relationship;
 use bevy::ecs::schedule::{InternedScheduleLabel, ScheduleLabel};
 use bevy::prelude::*;
-// use bevy::ecs::relationship::Relationship;
 use bevy_tnua_physics_integration_layer::math::AsF32;
 use bevy_tnua_physics_integration_layer::math::Float;
 use bevy_tnua_physics_integration_layer::math::Vector3;

--- a/demos/Cargo.toml
+++ b/demos/Cargo.toml
@@ -3,9 +3,7 @@ name = "tnua-demos-crate"
 version = "0.0.0"
 publish = false
 edition = "2021"
-exclude = [
-    "assets",
-]
+exclude = ["assets"]
 
 [features]
 default = [
@@ -14,13 +12,13 @@ default = [
     "avian3d?/f32",
     "avian3d?/parry-f32",
     # Comment these out when Bevy gets upgraded and a dependency lags behind
-    "egui",
+    # "egui",
 ]
 egui = ["dep:bevy_egui", "dep:egui_plot", "dep:egui_extras"]
 framepace = ["dep:bevy_framepace"] # Not a default feature
-rapier = []
-rapier2d = ["rapier", "dep:bevy_rapier2d", "dep:bevy-tnua-rapier2d"]
-rapier3d = ["rapier", "dep:bevy_rapier3d", "dep:bevy-tnua-rapier3d"]
+# rapier = []
+# rapier2d = ["rapier", "dep:bevy_rapier2d", "dep:bevy-tnua-rapier2d"]
+# rapier3d = ["rapier", "dep:bevy_rapier3d", "dep:bevy-tnua-rapier3d"]
 f64 = [
     "avian2d?/f64",
     "avian2d?/parry-f64",
@@ -35,8 +33,8 @@ avian2d = ["avian", "dep:avian2d", "dep:bevy-tnua-avian2d"]
 avian3d = ["avian", "dep:avian3d", "dep:bevy-tnua-avian3d"]
 
 [dependencies]
-bevy = { version = "^0.15", default-features = false, features = [
-     "animation",
+bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+    "animation",
     "bevy_asset",
     # "bevy_audio",
     "bevy_gilrs",
@@ -59,19 +57,34 @@ bevy = { version = "^0.15", default-features = false, features = [
 bevy-tnua = { path = ".." }
 bevy-tnua-physics-integration-layer = { path = "../physics-integration-layer" }
 
-bevy_rapier2d = { version = "^0.29", features = ["debug-render-2d"], optional = true }
-bevy-tnua-rapier2d = { path = "../rapier2d", optional = true }
+# bevy_rapier2d = { version = "^0.29", features = [
+#     "debug-render-2d",
+# ], optional = true }
+# bevy-tnua-rapier2d = { path = "../rapier2d", optional = true }
 
-bevy_rapier3d = { version = "^0.29", features = ["debug-render-3d"], optional = true }
-bevy-tnua-rapier3d = { path = "../rapier3d", optional = true }
+# bevy_rapier3d = { version = "^0.29", features = [
+#     "debug-render-3d",
+# ], optional = true }
+# bevy-tnua-rapier3d = { path = "../rapier3d", optional = true }
 
-avian2d = { version = "^0.2", default-features = false, features = ["2d","debug-plugin", "parallel"], optional = true}
+avian2d = { git = "https://github.com/Jondolf/avian.git", rev = "f041bf678dd8b75cf4408fc08cc3c6036bcdafb4", default-features = false, features = [
+    "2d",
+    "debug-plugin",
+    "parallel",
+], optional = true }
 bevy-tnua-avian2d = { path = "../avian2d", default-features = false, optional = true }
 
-avian3d = { version = "^0.2", default-features = false, features = ["3d","debug-plugin", "parallel"], optional = true }
+avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "f041bf678dd8b75cf4408fc08cc3c6036bcdafb4", default-features = false, features = [
+    "3d",
+    "debug-plugin",
+    "parallel",
+], optional = true }
 bevy-tnua-avian3d = { path = "../avian3d", default-features = false, optional = true }
 
-bevy_egui = { version = "0.33", optional = true, default-features = false, features = ["default_fonts", "render"] }
+bevy_egui = { version = "0.33", optional = true, default-features = false, features = [
+    "default_fonts",
+    "render",
+] }
 egui_plot = { version = "0.31", optional = true }
 egui_extras = { version = "0.31", optional = true }
 
@@ -80,4 +93,9 @@ bevy_framepace = { version = "0.18", optional = true }
 clap = { version = "^4", features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "^0.3", features = ["Window", "Location", "Url", "UrlSearchParams"] }
+web-sys = { version = "^0.3", features = [
+    "Window",
+    "Location",
+    "Url",
+    "UrlSearchParams",
+] }

--- a/demos/Cargo.toml
+++ b/demos/Cargo.toml
@@ -33,7 +33,7 @@ avian2d = ["avian", "dep:avian2d", "dep:bevy-tnua-avian2d"]
 avian3d = ["avian", "dep:avian3d", "dep:bevy-tnua-avian3d"]
 
 [dependencies]
-bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+bevy = { version = "0.16.0-rc.5", default-features = false, features = [
     "animation",
     "bevy_asset",
     # "bevy_audio",
@@ -67,14 +67,14 @@ bevy-tnua-physics-integration-layer = { path = "../physics-integration-layer" }
 # ], optional = true }
 # bevy-tnua-rapier3d = { path = "../rapier3d", optional = true }
 
-avian2d = { git = "https://github.com/Jondolf/avian.git", rev = "f041bf678dd8b75cf4408fc08cc3c6036bcdafb4", default-features = false, features = [
+avian2d = { git = "https://github.com/Jondolf/avian.git", rev = "7211ecfebb263412f3f0dc095c6e16e12615a229", default-features = false, features = [
     "2d",
     "debug-plugin",
     "parallel",
 ], optional = true }
 bevy-tnua-avian2d = { path = "../avian2d", default-features = false, optional = true }
 
-avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "f041bf678dd8b75cf4408fc08cc3c6036bcdafb4", default-features = false, features = [
+avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "7211ecfebb263412f3f0dc095c6e16e12615a229", default-features = false, features = [
     "3d",
     "debug-plugin",
     "parallel",

--- a/demos/Cargo.toml
+++ b/demos/Cargo.toml
@@ -67,14 +67,14 @@ bevy-tnua-physics-integration-layer = { path = "../physics-integration-layer" }
 # ], optional = true }
 # bevy-tnua-rapier3d = { path = "../rapier3d", optional = true }
 
-avian2d = { git = "https://github.com/Jondolf/avian.git", rev = "7211ecfebb263412f3f0dc095c6e16e12615a229", default-features = false, features = [
+avian2d = { git = "https://github.com/Jondolf/avian.git", rev = "f0d5b86b582c0d7074f0b084dd666e549acc767e", default-features = false, features = [
     "2d",
     "debug-plugin",
     "parallel",
 ], optional = true }
 bevy-tnua-avian2d = { path = "../avian2d", default-features = false, optional = true }
 
-avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "7211ecfebb263412f3f0dc095c6e16e12615a229", default-features = false, features = [
+avian3d = { git = "https://github.com/Jondolf/avian.git", rev = "f0d5b86b582c0d7074f0b084dd666e549acc767e", default-features = false, features = [
     "3d",
     "debug-plugin",
     "parallel",

--- a/demos/src/bin/shooter_like.rs
+++ b/demos/src/bin/shooter_like.rs
@@ -378,7 +378,7 @@ fn grab_ungrab_mouse(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut primary_window_query: Query<&mut Window, With<PrimaryWindow>>,
 ) {
-    let Ok(mut window) = primary_window_query.get_single_mut() else {
+    let Ok(mut window) = primary_window_query.single_mut() else {
         return;
     };
     if window.cursor_options.visible {
@@ -405,7 +405,7 @@ fn apply_camera_controls(
     mut camera_query: Query<&mut Transform, With<Camera>>,
 ) {
     let mouse_controls_camera = primary_window_query
-        .get_single()
+        .single()
         .is_ok_and(|w| !w.cursor_options.visible);
     let total_delta = if mouse_controls_camera {
         mouse_motion.read().map(|event| event.delta).sum()
@@ -413,7 +413,7 @@ fn apply_camera_controls(
         mouse_motion.clear();
         Vec2::ZERO
     };
-    let Ok((player_transform, mut forward_from_camera)) = player_character_query.get_single_mut()
+    let Ok((player_transform, mut forward_from_camera)) = player_character_query.single_mut()
     else {
         return;
     };

--- a/demos/src/level_mechanics/cannon.rs
+++ b/demos/src/level_mechanics/cannon.rs
@@ -81,6 +81,6 @@ fn handle_collision(
             continue;
         }
         (bullet.effect)(&mut commands.entity(player_entity));
-        commands.entity(bullet_entity).despawn_recursive();
+        commands.entity(bullet_entity).despawn();
     }
 }

--- a/demos/src/level_mechanics/moving_platform.rs
+++ b/demos/src/level_mechanics/moving_platform.rs
@@ -1,4 +1,7 @@
-use bevy::prelude::*;
+use bevy::{
+    ecs::{component::Mutable, system::ScheduleSystem},
+    prelude::*,
+};
 use bevy_tnua::math::{AdjustPrecision, Float, Vector3};
 
 pub struct MovingPlatformPlugin;
@@ -60,9 +63,9 @@ impl MovingPlatform {
         }
     }
 
-    fn make_system<V: Component>(
+    fn make_system<V: Component<Mutability = Mutable>>(
         mut updater: impl 'static + Send + Sync + FnMut(&mut V, Vector3),
-    ) -> bevy::ecs::schedule::SystemConfigs {
+    ) -> bevy::ecs::schedule::ScheduleConfigs<ScheduleSystem> {
         (move |time: Res<Time>,
                mut query: Query<(&mut MovingPlatform, &GlobalTransform, &mut V)>| {
             for (mut moving_platform, transform, mut velocity) in query.iter_mut() {

--- a/demos/src/level_mechanics/time_to_despawn.rs
+++ b/demos/src/level_mechanics/time_to_despawn.rs
@@ -24,7 +24,7 @@ fn handle_despawn(
 ) {
     for (entity, mut ttd) in query.iter_mut() {
         if ttd.0.tick(time.delta()).just_finished() {
-            commands.entity(entity).despawn_recursive();
+            commands.entity(entity).despawn();
         }
     }
 }

--- a/demos/src/levels_setup/level_switching.rs
+++ b/demos/src/levels_setup/level_switching.rs
@@ -122,7 +122,7 @@ fn handle_level_switching(
     };
     switchable_levels.current = *new_level_index;
     for entity in query.iter() {
-        commands.entity(entity).despawn_recursive();
+        commands.entity(entity).despawn();
     }
     commands.run_system(switchable_levels.current().level);
 }
@@ -192,6 +192,6 @@ fn handle_player_positioning(
         }
     }
     if position_player.ttl.tick(time.delta()).finished() {
-        commands.entity(positioner_entity).despawn_recursive();
+        commands.entity(positioner_entity).despawn();
     }
 }

--- a/demos/src/levels_setup/level_switching.rs
+++ b/demos/src/levels_setup/level_switching.rs
@@ -75,7 +75,7 @@ impl Plugin for LevelSwitchingPlugin {
         app.add_event::<SwitchToLevel>();
         app.add_systems(Update, (handle_level_switching, handle_player_positioning));
         app.add_systems(Startup, move |mut writer: EventWriter<SwitchToLevel>| {
-            writer.send(SwitchToLevel(level_index));
+            writer.write(SwitchToLevel(level_index));
         });
     }
 }

--- a/demos/src/ui/mod.rs
+++ b/demos/src/ui/mod.rs
@@ -9,6 +9,7 @@ pub mod tuning;
 
 use std::marker::PhantomData;
 
+use bevy::ecs::component::Mutable;
 use bevy::prelude::*;
 #[cfg(feature = "egui")]
 use bevy::window::{PresentMode, PrimaryWindow};
@@ -43,7 +44,7 @@ impl<C: Component + UiTunable> Default for DemoUi<C> {
 
 const GRAVITY_MAGNITUDE: Float = 9.81;
 
-impl<C: Component + UiTunable> Plugin for DemoUi<C> {
+impl<C: Component<Mutability = Mutable> + UiTunable> Plugin for DemoUi<C> {
     fn build(&self, app: &mut App) {
         #[cfg(feature = "egui")]
         app.add_plugins(EguiPlugin);
@@ -123,7 +124,7 @@ fn apply_selectors(
 
 #[cfg(feature = "egui")]
 #[allow(clippy::type_complexity)]
-fn ui_system<C: Component + UiTunable>(
+fn ui_system<C: Component<Mutability = Mutable> + UiTunable>(
     mut egui_context: EguiContexts,
     mut physics_backend_settings: ResMut<DemoUiPhysicsBackendSettings>,
     mut query: Query<(
@@ -145,7 +146,7 @@ fn ui_system<C: Component + UiTunable>(
 ) {
     use std::any::TypeId;
 
-    let Ok(mut primary_window) = primary_window_query.get_single_mut() else {
+    let Ok(mut primary_window) = primary_window_query.single_mut() else {
         return;
     };
     let mut egui_window = egui::Window::new("Tnua");

--- a/demos/src/util/animating.rs
+++ b/demos/src/util/animating.rs
@@ -1,5 +1,5 @@
 use bevy::gltf::Gltf;
-use bevy::platform_support::collections::HashMap;
+use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 
 #[derive(Component)]
@@ -47,7 +47,7 @@ pub fn animation_patcher_system(
                 break;
             }
             entity = if let Ok(child_of) = child_of_query.get(entity) {
-                child_of.parent
+                child_of.parent()
             } else {
                 break;
             };

--- a/demos/src/util/animating.rs
+++ b/demos/src/util/animating.rs
@@ -1,6 +1,6 @@
 use bevy::gltf::Gltf;
+use bevy::platform_support::collections::HashMap;
 use bevy::prelude::*;
-use bevy::utils::HashMap;
 
 #[derive(Component)]
 pub struct AnimationsHandler {
@@ -15,7 +15,7 @@ pub struct GltfSceneHandler {
 
 pub fn animation_patcher_system(
     animation_players_query: Query<Entity, Added<AnimationPlayer>>,
-    parents_query: Query<&Parent>,
+    child_of_query: Query<&ChildOf>,
     scene_handlers_query: Query<&GltfSceneHandler>,
     gltf_assets: Res<Assets<Gltf>>,
     mut animation_graphs_assets: ResMut<Assets<AnimationGraph>>,
@@ -28,7 +28,7 @@ pub fn animation_patcher_system(
                 let gltf = gltf_assets.get(names_from).unwrap();
                 let mut graph = AnimationGraph::new();
                 let root_node = graph.root;
-                let mut animations = HashMap::<String, AnimationNodeIndex>::new();
+                let mut animations = HashMap::<String, AnimationNodeIndex>::default();
 
                 for (name, clip) in gltf.named_animations.iter() {
                     let node_index = graph.add_clip(clip.clone(), 1.0, root_node);
@@ -46,8 +46,8 @@ pub fn animation_patcher_system(
                     .insert(AnimationGraphHandle(animation_graphs_assets.add(graph)));
                 break;
             }
-            entity = if let Ok(parent) = parents_query.get(entity) {
-                **parent
+            entity = if let Ok(child_of) = child_of_query.get(entity) {
+                child_of.parent
             } else {
                 break;
             };

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -97,7 +97,7 @@ fn setup_player(
 }
 
 fn apply_controls(keyboard: Res<ButtonInput<KeyCode>>, mut query: Query<&mut TnuaController>) {
-    let Ok(mut controller) = query.get_single_mut() else {
+    let Ok(mut controller) = query.single_mut() else {
         return;
     };
 

--- a/examples/example_animating.rs
+++ b/examples/example_animating.rs
@@ -133,7 +133,7 @@ fn prepare_animations(
     let Some(gltf) = gltf_assets.get(&handle.0) else {
         return;
     };
-    let Ok(animation_player_entity) = animation_player_query.get_single() else {
+    let Ok(animation_player_entity) = animation_player_query.single() else {
         return;
     };
 
@@ -156,7 +156,7 @@ fn prepare_animations(
 }
 
 fn apply_controls(keyboard: Res<ButtonInput<KeyCode>>, mut query: Query<&mut TnuaController>) {
-    let Ok(mut controller) = query.get_single_mut() else {
+    let Ok(mut controller) = query.single_mut() else {
         return;
     };
 
@@ -210,10 +210,10 @@ fn handle_animating(
 ) {
     // An actual game should match the animation player and the controller. Here we cheat for
     // simplicity and use the only controller and only player.
-    let Ok((controller, mut animating_state)) = player_query.get_single_mut() else {
+    let Ok((controller, mut animating_state)) = player_query.single_mut() else {
         return;
     };
-    let Ok(mut animation_player) = animation_player_query.get_single_mut() else {
+    let Ok(mut animation_player) = animation_player_query.single_mut() else {
         return;
     };
     let Some(animation_nodes) = animation_nodes else {

--- a/physics-integration-layer/Cargo.toml
+++ b/physics-integration-layer/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/bevy-tnua-physics-integration-layer"
 readme = "../README.md"
 
 [dependencies]
-bevy = { version = "0.16.0-rc.3", default-features = false }
+bevy = { version = "0.16.0-rc.5", default-features = false }
 
 [features]
 f64 = []

--- a/physics-integration-layer/Cargo.toml
+++ b/physics-integration-layer/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/bevy-tnua-physics-integration-layer"
 readme = "../README.md"
 
 [dependencies]
-bevy = { version = "^0.15", default-features = false }
+bevy = { version = "0.16.0-rc.3", default-features = false }
 
 [features]
 f64 = []

--- a/rapier2d/Cargo.toml
+++ b/rapier2d/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 # bevy_render is required because bevy_rapier uses bevy::render::primitives::Aabb
-bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+bevy = { version = "0.16.0-rc.5", default-features = false, features = [
     "bevy_render",
 ] }
 bevy_rapier2d = { version = "^0.29", default-features = false, features = [

--- a/rapier2d/Cargo.toml
+++ b/rapier2d/Cargo.toml
@@ -13,8 +13,12 @@ readme = "../README.md"
 
 [dependencies]
 # bevy_render is required because bevy_rapier uses bevy::render::primitives::Aabb
-bevy = { version = "^0.15", default-features = false, features = ["bevy_render"] }
-bevy_rapier2d = { version = "^0.29", default-features = false, features = ["dim2"] }
+bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+    "bevy_render",
+] }
+bevy_rapier2d = { version = "^0.29", default-features = false, features = [
+    "dim2",
+] }
 bevy-tnua-physics-integration-layer = { version = "^0.6", path = "../physics-integration-layer" }
 
 [package.metadata.docs.rs]

--- a/rapier3d/Cargo.toml
+++ b/rapier3d/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 # bevy_render is required because bevy_rapier uses bevy::render::primitives::Aabb
-bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+bevy = { version = "0.16.0-rc.5", default-features = false, features = [
     "bevy_render",
 ] }
 bevy_rapier3d = { version = "^0.29", default-features = false, features = [

--- a/rapier3d/Cargo.toml
+++ b/rapier3d/Cargo.toml
@@ -13,8 +13,12 @@ readme = "../README.md"
 
 [dependencies]
 # bevy_render is required because bevy_rapier uses bevy::render::primitives::Aabb
-bevy = { version = "^0.15", default-features = false, features = ["bevy_render"] }
-bevy_rapier3d = { version = "^0.29", default-features = false, features = ["dim3"]}
+bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+    "bevy_render",
+] }
+bevy_rapier3d = { version = "^0.29", default-features = false, features = [
+    "dim3",
+] }
 bevy-tnua-physics-integration-layer = { version = "^0.6", path = "../physics-integration-layer" }
 
 [package.metadata.docs.rs]

--- a/src/control_helpers/crouch_enforcer.rs
+++ b/src/control_helpers/crouch_enforcer.rs
@@ -213,9 +213,7 @@ fn update_crouch_enforcer(
                         ..Default::default()
                     },
                 ));
-                cmd.insert(ChildOf {
-                    parent: owner_entity,
-                });
+                cmd.insert(ChildOf(owner_entity));
                 (crouch_enforcer.modify_sensor)(&mut cmd);
                 let sensor_entity = cmd.id();
                 crouch_enforcer.sensor_entity = Some(sensor_entity);

--- a/src/control_helpers/crouch_enforcer.rs
+++ b/src/control_helpers/crouch_enforcer.rs
@@ -213,7 +213,9 @@ fn update_crouch_enforcer(
                         ..Default::default()
                     },
                 ));
-                cmd.set_parent(owner_entity);
+                cmd.insert(ChildOf {
+                    parent: owner_entity,
+                });
                 (crouch_enforcer.modify_sensor)(&mut cmd);
                 let sensor_entity = cmd.id();
                 crouch_enforcer.sensor_entity = Some(sensor_entity);

--- a/src/control_helpers/simple_fall_through_platforms.rs
+++ b/src/control_helpers/simple_fall_through_platforms.rs
@@ -1,4 +1,4 @@
-use bevy::{platform_support::collections::HashSet, prelude::*};
+use bevy::{platform::collections::HashSet, prelude::*};
 use bevy_tnua_physics_integration_layer::math::Float;
 
 use crate::{TnuaGhostSensor, TnuaProximitySensor};

--- a/src/control_helpers/simple_fall_through_platforms.rs
+++ b/src/control_helpers/simple_fall_through_platforms.rs
@@ -1,5 +1,4 @@
-use bevy::prelude::*;
-use bevy::utils::HashSet;
+use bevy::{platform_support::collections::HashSet, prelude::*};
 use bevy_tnua_physics_integration_layer::math::Float;
 
 use crate::{TnuaGhostSensor, TnuaProximitySensor};

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,5 +1,5 @@
 use bevy::ecs::schedule::{InternedScheduleLabel, ScheduleLabel};
-use bevy::platform_support::collections::hash_map::{Entry, HashMap};
+use bevy::platform::collections::hash_map::{Entry, HashMap};
 use bevy::prelude::*;
 use bevy::time::Stopwatch;
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,7 +1,8 @@
 use bevy::ecs::schedule::{InternedScheduleLabel, ScheduleLabel};
+use bevy::platform_support::collections::hash_map::{Entry, HashMap};
 use bevy::prelude::*;
 use bevy::time::Stopwatch;
-use bevy::utils::{Entry, HashMap};
+
 use bevy_tnua_physics_integration_layer::math::{AsF32, Float};
 
 use crate::basis_action_traits::{


### PR DESCRIPTION
Hey,

I wanted to use tnua for my 0.16 project, and for some reason I ended up porting tnua instead of downgrading my project.
This branch works, at least for this demo:
```
bevy run --bin shooter_like --features avian3d
```

Does this PR look useful to you? I probably won't have the time to actually support it further, but I wanted to push it as a PR instead of having it just sit locally on my PC.

Given that rapier isn't supported, and that avian needs bevy 0.16 rc2 to work, I doubt this can be merged soon.

(God do I really hope I didn't just miss an existing 0.16 branch)

### Random Notes
- For the same reason as https://github.com/rust-adventure/skein/issues/27, I ended up needing to be very explicit with the bevy dependencies - hopefully that won't be necessary soon.
- The TOML formatting changes were automatically made by vscode - do you have a fomatter I can use to revert them? If not, most of the cargo changes are temporary patches either way, so most stuff will be removed either way.
- Some stuff, such as `ChildOf {parent: foo}` -> `ChildOf(foo)` will have to be changed when bumping bevy from rc3 to rc4.
- I think you can find the reason for all of my non-Cargo changes by ctrl-f ing them in the migration guide (https://bevyengine.org/learn/migration-guides/0-15-to-0-16/).
I never touched tnua before - so I may have missed important context when making changes.

Thank you for the awesome library! It was so surprising to see that it supports both rapier and avian