### PR TITLE
Add Default impl to SensorShapes for ergonomics

### DIFF
--- a/avian2d/src/lib.rs
+++ b/avian2d/src/lib.rs
@@ -82,7 +82,7 @@ impl Plugin for TnuaAvian2dPlugin {
 }
 
 /// Add this component to make [`TnuaProximitySensor`] cast a shape instead of a ray.
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct TnuaAvian2dSensorShape(pub Collider);
 
 #[allow(clippy::type_complexity)]

--- a/avian3d/src/lib.rs
+++ b/avian3d/src/lib.rs
@@ -91,7 +91,7 @@ impl Plugin for TnuaAvian3dPlugin {
 }
 
 /// Add this component to make [`TnuaProximitySensor`] cast a shape instead of a ray.
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct TnuaAvian3dSensorShape(pub Collider);
 
 #[allow(clippy::type_complexity)]

--- a/rapier2d/src/lib.rs
+++ b/rapier2d/src/lib.rs
@@ -107,7 +107,7 @@ pub struct TnuaRapier2dIOBundle {
 }
 
 /// Add this component to make [`TnuaProximitySensor`] cast a shape instead of a ray.
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct TnuaRapier2dSensorShape(pub Collider);
 
 fn update_rigid_body_trackers_system(

--- a/rapier3d/src/lib.rs
+++ b/rapier3d/src/lib.rs
@@ -107,7 +107,7 @@ pub struct TnuaRapier3dIOBundle {
 }
 
 /// Add this component to make [`TnuaProximitySensor`] cast a shape instead of a ray.
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct TnuaRapier3dSensorShape(pub Collider);
 
 fn update_rigid_body_trackers_system(


### PR DESCRIPTION
Thanks for the great plugin! I've found that `TnuaAvian2dSensorShape` are needed by the engine to handle the "floating capsule" physics, so I thought it'd be nice to add some `Default`s to make them easier to work with.

Thanks!