### PR TITLE
Migration to bevy 0.19 requires a modern toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        rust: [1.92.0, nightly]
+        rust: [1.96.0, nightly]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -61,7 +61,7 @@ jobs:
      - uses: actions/checkout@v3
      - uses: dtolnay/rust-toolchain@master
        with:
-         toolchain: 1.92.0
+         toolchain: 1.96.0
          components: rustfmt
      - name: Run fmt --all -- --check
        run: cargo fmt --all -- --check
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.92.0
+          toolchain: 1.96.0
           components: clippy
       - name: Install dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.92.0
+          toolchain: 1.96.0
       - name: Install dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev
       - name: Cache cargo
@@ -144,7 +144,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           targets: wasm32-unknown-unknown
-          toolchain: 1.92.0
+          toolchain: 1.96.0
       - name: Get package names
         id: get-package-names
         run: |-


### PR DESCRIPTION
About to close down #129 

As I prefer PR's with single responsibility 

So I am stripping out the action/checkout changes -- that still needs doing but is a maintenance PR