### PR TITLE
Avian Non-Uniform Gravity Fix

### DIFF
--- a/avian2d/src/lib.rs
+++ b/avian2d/src/lib.rs
@@ -414,36 +414,33 @@ fn update_obstacle_radars_system(
 fn apply_motors_system(
     mut query: Query<(
         &TnuaMotor,
-        &ComputedMass,
-        &ComputedAngularInertia,
         Forces,
         Option<&TnuaToggle>,
         Option<&TnuaGravity>,
     )>,
 ) {
-    for (motor, mass, inertia, mut forces, tnua_toggle, tnua_gravity) in query.iter_mut() {
+    for (motor, mut forces, tnua_toggle, tnua_gravity) in query.iter_mut() {
         match tnua_toggle.copied().unwrap_or_default() {
             TnuaToggle::Disabled | TnuaToggle::SenseOnly => {
                 return;
             }
             TnuaToggle::Enabled => {}
         }
+
         if motor.lin.boost.is_finite() {
-            forces.apply_linear_impulse(motor.lin.boost.truncate() * mass.value());
+            *forces.linear_velocity_mut() += motor.lin.boost.truncate();
         }
         if motor.lin.acceleration.is_finite() {
-            forces.apply_force(motor.lin.acceleration.truncate() * mass.value());
+            forces.apply_force(motor.lin.acceleration.truncate());
         }
         if motor.ang.boost.is_finite() {
-            forces.apply_angular_impulse(inertia.value() * motor.ang.boost.z);
+            *forces.angular_velocity_mut() += motor.ang.boost.length();
         }
         if motor.ang.acceleration.is_finite() {
-            // NOTE: I did not actually verify that this is correct. Nothing uses angular
-            // acceleration yet - only angular impulses.
-            forces.apply_angular_acceleration(motor.ang.acceleration.z);
+            forces.apply_torque(motor.ang.acceleration.length());
         }
         if let Some(gravity) = tnua_gravity {
-            forces.apply_force(gravity.0.truncate() * mass.value());
+            forces.apply_force(gravity.0.truncate());
         }
     }
 }

--- a/avian2d/src/lib.rs
+++ b/avian2d/src/lib.rs
@@ -414,13 +414,12 @@ fn update_obstacle_radars_system(
 fn apply_motors_system(
     mut query: Query<(
         &TnuaMotor,
-        &ComputedMass,
         Forces,
         Option<&TnuaToggle>,
         Option<&TnuaGravity>,
     )>,
 ) {
-    for (motor, mass, mut forces, tnua_toggle, tnua_gravity) in query.iter_mut() {
+    for (motor, mut forces, tnua_toggle, tnua_gravity) in query.iter_mut() {
         match tnua_toggle.copied().unwrap_or_default() {
             TnuaToggle::Disabled | TnuaToggle::SenseOnly => {
                 return;
@@ -432,7 +431,7 @@ fn apply_motors_system(
             *forces.linear_velocity_mut() += motor.lin.boost.truncate();
         }
         if motor.lin.acceleration.is_finite() {
-            forces.apply_force(motor.lin.acceleration.truncate() * mass.value());
+            forces.apply_linear_acceleration(motor.lin.acceleration.truncate());
         }
         if motor.ang.boost.is_finite() {
             *forces.angular_velocity_mut() += motor.ang.boost.z;
@@ -441,7 +440,7 @@ fn apply_motors_system(
             forces.apply_torque(motor.ang.acceleration.z);
         }
         if let Some(gravity) = tnua_gravity {
-            forces.apply_force(gravity.0.truncate() * mass.value());
+            forces.apply_linear_acceleration(gravity.0.truncate());
         }
     }
 }

--- a/avian2d/src/lib.rs
+++ b/avian2d/src/lib.rs
@@ -414,12 +414,13 @@ fn update_obstacle_radars_system(
 fn apply_motors_system(
     mut query: Query<(
         &TnuaMotor,
+        &ComputedMass,
         Forces,
         Option<&TnuaToggle>,
         Option<&TnuaGravity>,
     )>,
 ) {
-    for (motor, mut forces, tnua_toggle, tnua_gravity) in query.iter_mut() {
+    for (motor, mass, mut forces, tnua_toggle, tnua_gravity) in query.iter_mut() {
         match tnua_toggle.copied().unwrap_or_default() {
             TnuaToggle::Disabled | TnuaToggle::SenseOnly => {
                 return;
@@ -431,7 +432,7 @@ fn apply_motors_system(
             *forces.linear_velocity_mut() += motor.lin.boost.truncate();
         }
         if motor.lin.acceleration.is_finite() {
-            forces.apply_force(motor.lin.acceleration.truncate());
+            forces.apply_force(motor.lin.acceleration.truncate() * mass.value());
         }
         if motor.ang.boost.is_finite() {
             *forces.angular_velocity_mut() += motor.ang.boost.length();
@@ -440,7 +441,7 @@ fn apply_motors_system(
             forces.apply_torque(motor.ang.acceleration.length());
         }
         if let Some(gravity) = tnua_gravity {
-            forces.apply_force(gravity.0.truncate());
+            forces.apply_force(gravity.0.truncate() * mass.value());
         }
     }
 }

--- a/avian2d/src/lib.rs
+++ b/avian2d/src/lib.rs
@@ -435,10 +435,10 @@ fn apply_motors_system(
             forces.apply_force(motor.lin.acceleration.truncate() * mass.value());
         }
         if motor.ang.boost.is_finite() {
-            *forces.angular_velocity_mut() += motor.ang.boost.length();
+            *forces.angular_velocity_mut() += motor.ang.boost.z;
         }
         if motor.ang.acceleration.is_finite() {
-            forces.apply_torque(motor.ang.acceleration.length());
+            forces.apply_torque(motor.ang.acceleration.z);
         }
         if let Some(gravity) = tnua_gravity {
             forces.apply_force(gravity.0.truncate() * mass.value());

--- a/avian3d/src/lib.rs
+++ b/avian3d/src/lib.rs
@@ -419,13 +419,12 @@ fn update_obstacle_radars_system(
 fn apply_motors_system(
     mut query: Query<(
         &TnuaMotor,
-        &ComputedMass,
         Forces,
         Option<&TnuaToggle>,
         Option<&TnuaGravity>,
     )>,
 ) {
-    for (motor, mass, mut forces, tnua_toggle, tnua_gravity) in query.iter_mut() {
+    for (motor, mut forces, tnua_toggle, tnua_gravity) in query.iter_mut() {
         match tnua_toggle.copied().unwrap_or_default() {
             TnuaToggle::Disabled | TnuaToggle::SenseOnly => {
                 return;
@@ -437,7 +436,7 @@ fn apply_motors_system(
             *forces.linear_velocity_mut() += motor.lin.boost;
         }
         if motor.lin.acceleration.is_finite() {
-            forces.apply_force(motor.lin.acceleration * mass.value());
+            forces.apply_linear_acceleration(motor.lin.acceleration);
         }
         if motor.ang.boost.is_finite() {
             *forces.angular_velocity_mut() += motor.ang.boost;
@@ -446,7 +445,7 @@ fn apply_motors_system(
             forces.apply_torque(motor.ang.acceleration);
         }
         if let Some(gravity) = tnua_gravity {
-            forces.apply_force(gravity.0 * mass.value());
+            forces.apply_linear_acceleration(gravity.0);
         }
     }
 }

--- a/avian3d/src/lib.rs
+++ b/avian3d/src/lib.rs
@@ -419,12 +419,13 @@ fn update_obstacle_radars_system(
 fn apply_motors_system(
     mut query: Query<(
         &TnuaMotor,
+        &ComputedMass,
         Forces,
         Option<&TnuaToggle>,
         Option<&TnuaGravity>,
     )>,
 ) {
-    for (motor, mut forces, tnua_toggle, tnua_gravity) in query.iter_mut() {
+    for (motor, mass, mut forces, tnua_toggle, tnua_gravity) in query.iter_mut() {
         match tnua_toggle.copied().unwrap_or_default() {
             TnuaToggle::Disabled | TnuaToggle::SenseOnly => {
                 return;
@@ -436,7 +437,7 @@ fn apply_motors_system(
             *forces.linear_velocity_mut() += motor.lin.boost;
         }
         if motor.lin.acceleration.is_finite() {
-            forces.apply_force(motor.lin.acceleration);
+            forces.apply_force(motor.lin.acceleration * mass.value());
         }
         if motor.ang.boost.is_finite() {
             *forces.angular_velocity_mut() += motor.ang.boost;
@@ -445,7 +446,7 @@ fn apply_motors_system(
             forces.apply_torque(motor.ang.acceleration);
         }
         if let Some(gravity) = tnua_gravity {
-            forces.apply_force(gravity.0);
+            forces.apply_force(gravity.0 * mass.value());
         }
     }
 }

--- a/avian3d/src/lib.rs
+++ b/avian3d/src/lib.rs
@@ -11,23 +11,19 @@ mod spatial_ext;
 use avian3d::{prelude::*, schedule::PhysicsStepSystems};
 use bevy::ecs::schedule::{InternedScheduleLabel, ScheduleLabel};
 use bevy::prelude::*;
-use bevy_tnua_physics_integration_layer::math::AsF32;
-use bevy_tnua_physics_integration_layer::math::Float;
-use bevy_tnua_physics_integration_layer::math::Vector3;
-use bevy_tnua_physics_integration_layer::math::{AdjustPrecision, Quaternion};
 use ordered_float::OrderedFloat;
 pub use spatial_ext::TnuaSpatialExtAvian3d;
 
-use bevy_tnua_physics_integration_layer::TnuaPipelineSystems;
-use bevy_tnua_physics_integration_layer::TnuaSystems;
-use bevy_tnua_physics_integration_layer::data_for_backends::TnuaGravity;
-use bevy_tnua_physics_integration_layer::data_for_backends::TnuaToggle;
-use bevy_tnua_physics_integration_layer::data_for_backends::{TnuaGhostPlatform, TnuaNotPlatform};
-use bevy_tnua_physics_integration_layer::data_for_backends::{TnuaGhostSensor, TnuaSensorOf};
-use bevy_tnua_physics_integration_layer::data_for_backends::{
-    TnuaMotor, TnuaProximitySensor, TnuaProximitySensorOutput, TnuaRigidBodyTracker,
+use bevy_tnua_physics_integration_layer::{
+    TnuaPipelineSystems, TnuaSystems,
+    data_for_backends::{
+        TnuaGhostPlatform, TnuaGhostSensor, TnuaGravity, TnuaMotor, TnuaNotPlatform,
+        TnuaProximitySensor, TnuaProximitySensorOutput, TnuaRigidBodyTracker, TnuaSensorOf,
+        TnuaToggle,
+    },
+    math::{AdjustPrecision, AsF32, Float, Quaternion, Vector3},
+    obstacle_radar::TnuaObstacleRadar,
 };
-use bevy_tnua_physics_integration_layer::obstacle_radar::TnuaObstacleRadar;
 
 pub mod prelude {
     pub use crate::{TnuaAvian3dPlugin, TnuaAvian3dSensorShape, TnuaSpatialExtAvian3d};
@@ -421,65 +417,35 @@ fn update_obstacle_radars_system(
 
 #[allow(clippy::type_complexity)]
 fn apply_motors_system(
-    mut commands: Commands,
     mut query: Query<(
-        Entity,
         &TnuaMotor,
-        &ComputedMass,
-        &ComputedAngularInertia,
-        &mut AngularVelocity,
-        &mut LinearVelocity,
-        Option<&mut ConstantTorque>,
-        Option<&mut ConstantForce>,
+        Forces,
         Option<&TnuaToggle>,
         Option<&TnuaGravity>,
     )>,
 ) {
-    for (
-        entity,
-        motor,
-        mass,
-        inertia,
-        mut ang_vel,
-        mut lin_vel,
-        mut constant_torque,
-        mut constant_force,
-        tnua_toggle,
-        tnua_gravity,
-    ) in query.iter_mut()
-    {
-        let (Some(constant_torque), Some(constant_force)) =
-            (constant_torque.as_mut(), constant_force.as_mut())
-        else {
-            commands
-                .entity(entity)
-                .insert((ConstantTorque::default(), ConstantForce::default()));
-            continue;
-        };
+    for (motor, mut forces, tnua_toggle, tnua_gravity) in query.iter_mut() {
         match tnua_toggle.copied().unwrap_or_default() {
             TnuaToggle::Disabled | TnuaToggle::SenseOnly => {
-                **constant_force = Default::default();
-                **constant_torque = Default::default();
                 return;
             }
             TnuaToggle::Enabled => {}
         }
 
         if motor.lin.boost.is_finite() {
-            **lin_vel += motor.lin.boost;
+            *forces.linear_velocity_mut() += motor.lin.boost;
         }
         if motor.lin.acceleration.is_finite() {
-            ***constant_force = motor.lin.acceleration * mass.value();
+            forces.apply_force(motor.lin.acceleration);
         }
         if motor.ang.boost.is_finite() {
-            **ang_vel += motor.ang.boost;
+            *forces.angular_velocity_mut() += motor.ang.boost;
         }
         if motor.ang.acceleration.is_finite() {
-            ***constant_torque =
-                motor.ang.acceleration * inertia.principal_angular_inertia_with_local_frame().0;
+            forces.apply_torque(motor.ang.acceleration);
         }
         if let Some(gravity) = tnua_gravity {
-            ***constant_force += gravity.0 * mass.value();
+            forces.apply_force(gravity.0);
         }
     }
 }

--- a/avian3d/src/lib.rs
+++ b/avian3d/src/lib.rs
@@ -421,39 +421,65 @@ fn update_obstacle_radars_system(
 
 #[allow(clippy::type_complexity)]
 fn apply_motors_system(
+    mut commands: Commands,
     mut query: Query<(
+        Entity,
         &TnuaMotor,
         &ComputedMass,
         &ComputedAngularInertia,
-        Forces,
+        &mut AngularVelocity,
+        &mut LinearVelocity,
+        Option<&mut ConstantTorque>,
+        Option<&mut ConstantForce>,
         Option<&TnuaToggle>,
         Option<&TnuaGravity>,
     )>,
 ) {
-    for (motor, mass, inertia, mut forces, tnua_toggle, tnua_gravity) in query.iter_mut() {
+    for (
+        entity,
+        motor,
+        mass,
+        inertia,
+        mut ang_vel,
+        mut lin_vel,
+        mut constant_torque,
+        mut constant_force,
+        tnua_toggle,
+        tnua_gravity,
+    ) in query.iter_mut()
+    {
+        let (Some(constant_torque), Some(constant_force)) =
+            (constant_torque.as_mut(), constant_force.as_mut())
+        else {
+            commands
+                .entity(entity)
+                .insert((ConstantTorque::default(), ConstantForce::default()));
+            continue;
+        };
         match tnua_toggle.copied().unwrap_or_default() {
             TnuaToggle::Disabled | TnuaToggle::SenseOnly => {
-                // *external_force = Default::default();
+                **constant_force = Default::default();
+                **constant_torque = Default::default();
                 return;
             }
             TnuaToggle::Enabled => {}
         }
+
         if motor.lin.boost.is_finite() {
-            forces.apply_linear_impulse(motor.lin.boost * mass.value());
+            **lin_vel += motor.lin.boost;
         }
         if motor.lin.acceleration.is_finite() {
-            forces.apply_linear_acceleration(motor.lin.acceleration);
+            ***constant_force = motor.lin.acceleration * mass.value();
         }
         if motor.ang.boost.is_finite() {
-            forces.apply_angular_impulse(inertia.value() * motor.ang.boost);
+            **ang_vel += motor.ang.boost;
         }
         if motor.ang.acceleration.is_finite() {
-            // NOTE: I did not actually verify that this is correct. Nothing uses angular
-            // acceleration yet - only angular impulses.
-            forces.apply_angular_acceleration(motor.ang.acceleration);
+            ***constant_torque =
+                motor.ang.acceleration * inertia.principal_angular_inertia_with_local_frame().0;
         }
         if let Some(gravity) = tnua_gravity {
-            forces.apply_force(gravity.0 * mass.value());
+            ***constant_force += gravity.0 * mass.value();
         }
     }
 }


### PR DESCRIPTION
- Replaced `apply_angular_acceleration` with `apply_torque`.
- tnua gravity is applied by using `apply_linear_acceleration` instead of `apply_force`.
- Both boost values are now applied by adding to `angular_velocity_mut` or `linear_velocity_mut` instead of `apply_XXX_impulse` to avoid mass or inertia multiplication.